### PR TITLE
Added feedback on connect four when clicked on a full column

### DIFF
--- a/games/Connect-four/script.js
+++ b/games/Connect-four/script.js
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let currentPlayer = PLAYER_RED;
     let gameOver = false;
 
-    function init(){
+    function init() {
         gameOver = false;
         currentPlayer = PLAYER_RED;
         playAgainBtn.classList.add('hidden');
@@ -22,21 +22,21 @@ document.addEventListener('DOMContentLoaded', () => {
         createBoard();
         updateGameStatus();
     }
-    
+
     startGameBtn.addEventListener('click', () => {
         startScreen.classList.add('hidden');
         gameArea.classList.remove('hidden');
         init();
     });
 
-    function createBoard(){
+    function createBoard() {
         gameBoard.innerHTML = '';
         board = [];
-        for(let c = 0; c < COLS; c++){
+        for (let c = 0; c < COLS; c++) {
             board.push(Array(ROWS).fill(null));
         }
-        for(let r = 0; r < ROWS; r++){
-            for(let c = 0; c < COLS; c++){
+        for (let r = 0; r < ROWS; r++) {
+            for (let c = 0; c < COLS; c++) {
                 const slot = document.createElement('div');
                 slot.classList.add('slot');
                 slot.dataset.col = c;
@@ -51,71 +51,78 @@ document.addEventListener('DOMContentLoaded', () => {
     gameBoard.addEventListener('mouseout', handleMouseOut);
     playAgainBtn.addEventListener('click', init);
 
-    function handleMouseOver(e){
-        if(gameOver) return;
+    function handleMouseOver(e) {
+        if (gameOver) return;
         const col = e.target.closest('.slot')?.dataset.col;
-        if(col){
+        if (col) {
             document.querySelectorAll(`.slot[data-col='${col}']`).forEach(slot => {
                 slot.classList.add('column-hover');
             });
         }
     }
 
-    function handleMouseOut(e){
+    function handleMouseOut(e) {
         const col = e.target.closest('.slot')?.dataset.col;
-        if(col){
+        if (col) {
             document.querySelectorAll(`.slot[data-col='${col}']`).forEach(slot => {
                 slot.classList.remove('column-hover');
             });
         }
     }
 
-    function handleBoardClick(e){
-        if(gameOver) return;
+    function handleBoardClick(e) {
+        if (gameOver) return;
         const col = parseInt(e.target.closest('.slot')?.dataset.col);
-        if(isNaN(col)) return;
+        if (isNaN(col)) return;
         const row = board[col].findIndex(slot => slot === null);
-        if(row === -1) return;
+
+        if (row === -1) {
+            // Column is full — show feedback
+            indicateFullColumn(col);
+            return;
+        }
+
         board[col][row] = currentPlayer;
         dropPiece(col, row, currentPlayer);
-        if(checkForWin(col, row)){
+        if (checkForWin(col, row)) {
             endGame(`${currentPlayer.charAt(0).toUpperCase() + currentPlayer.slice(1)} wins!`);
-        }else if(board.flat().every(slot => slot !== null)){
+        } else if (board.flat().every(slot => slot !== null)) {
             endGame("It's a tie!");
-        }else{
+        } else {
             switchPlayer();
         }
     }
 
-    function dropPiece(col, row, player){
+
+    function dropPiece(col, row, player) {
         const slot = document.querySelector(`.slot[data-col='${col}'][data-row='${row}']`);
         const piece = document.createElement('div');
         piece.classList.add('piece', player);
         slot.appendChild(piece);
     }
 
-    function switchPlayer(){
+    function switchPlayer() {
         currentPlayer = (currentPlayer === PLAYER_RED) ? PLAYER_YELLOW : PLAYER_RED;
         updateGameStatus();
     }
-    
-    function updateGameStatus(){
+
+    function updateGameStatus() {
         gameStatusEl.textContent = `${currentPlayer.charAt(0).toUpperCase() + currentPlayer.slice(1)}'s Turn`;
         gameStatusEl.style.color = currentPlayer === PLAYER_RED ? '#ef4444' : '#facc15';
     }
 
-    function checkForWin(col, row){
+    function checkForWin(col, row) {
         const player = board[col][row];
 
-        function checkDirection(dc, dr){
+        function checkDirection(dc, dr) {
             let count = 0;
-            for (let i = -3; i <= 3; i++){
+            for (let i = -3; i <= 3; i++) {
                 const c = col + i * dc;
                 const r = row + i * dr;
-                if(c >= 0 && c < COLS && r >= 0 && r < ROWS && board[c][r] === player){
+                if (c >= 0 && c < COLS && r >= 0 && r < ROWS && board[c][r] === player) {
                     count++;
-                    if(count === 4) return true;
-                }else{
+                    if (count === 4) return true;
+                } else {
                     count = 0;
                 }
             }
@@ -123,13 +130,21 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         return checkDirection(1, 0) || checkDirection(0, 1) || checkDirection(1, 1) || checkDirection(1, -1);
     }
-    
-    function endGame(message){
+
+    function endGame(message) {
         gameOver = true;
         gameStatusEl.textContent = message;
         gameStatusEl.style.color = '#ffffff';
         playAgainBtn.classList.remove('hidden');
         gameBoard.style.cursor = 'not-allowed';
     }
+    function indicateFullColumn(col) {
+        const slots = document.querySelectorAll(`.slot[data-col='${col}']`);
+        slots.forEach(slot => slot.classList.add('full-column-warning'));
+        setTimeout(() => {
+            slots.forEach(slot => slot.classList.remove('full-column-warning'));
+        }, 500);
+    }
+
 });
 

--- a/games/Connect-four/style.css
+++ b/games/Connect-four/style.css
@@ -111,4 +111,15 @@ h2{
 .column-hover{
     background-color: #374151;
 }
+.full-column-warning {
+    animation: shake 0.3s;
+    border: 2px solid #f87171; /* Red border as warning */
+}
+
+@keyframes shake {
+    0%, 100% { transform: translateX(0); }
+    20%, 60% { transform: translateX(-5px); }
+    40%, 80% { transform: translateX(5px); }
+}
+
 


### PR DESCRIPTION
This pull request improves the user experience by providing immediate visual feedback if a player tries to place a piece in a column that is already full. Instead of silently ignoring the click, the column briefly shakes with a red border to indicate that no further pieces can be dropped there.

Changes Made
Updated handleBoardClick to detect full columns and trigger feedback.
Added a new helper function indicateFullColumn to apply and remove a temporary warning style.
Defined new CSS animation .full-column-warning for shaking effect and red border.
Placed related CSS styles at the end of the stylesheet to avoid conflicts.

Impact
Enhances clarity and responsiveness during gameplay.
Prevents confusion or frustration due to unacknowledged invalid moves.
Maintains existing functionality with an incremental UX improvement.

Testing Instructions
Fill a column in the game completely.
Attempt to click the full column again.
Observe the column shaking with a red border indicating it is full.
Confirm no piece is added and the game continues normally otherwise.