### PR TITLE
Fix game restart bug by cancelling old animation frame

### DIFF
--- a/games/falling-leaves-collector/script.js
+++ b/games/falling-leaves-collector/script.js
@@ -9,6 +9,7 @@ let lives = 5;
 let leaves = [];
 let basket = { x: canvas.width / 2 - 40, y: canvas.height - 50, width: 80, height: 20, speed: 7 };
 let gameOver = false;
+let animationId; // store the animation frame id
 
 // Generate random leaves
 function createLeaf() {
@@ -62,18 +63,19 @@ function update() {
     // Add leaves randomly
     if (Math.random() < 0.02) createLeaf();
 
-    // Update leaf positions
-    leaves.forEach((leaf, index) => {
+    // Update leaf positions - iterate backwards for safe removal
+    for (let i = leaves.length - 1; i >= 0; i--) {
+        const leaf = leaves[i];
         leaf.y += leaf.speed;
         if (checkCollision(leaf)) {
             score += 10;
-            leaves.splice(index, 1);
+            leaves.splice(i, 1);
         } else if (leaf.y > canvas.height) {
             lives--;
-            leaves.splice(index, 1);
+            leaves.splice(i, 1);
             if (lives <= 0) gameOver = true;
         }
-    });
+    }
 
     drawLeaves();
     drawBasket();
@@ -88,7 +90,7 @@ function update() {
         ctx.fillText("Game Over!", canvas.width / 2, canvas.height / 2);
         ctx.fillText(`Score: ${score}`, canvas.width / 2, canvas.height / 2 + 40);
     } else {
-        requestAnimationFrame(update);
+        animationId = requestAnimationFrame(update);
     }
 }
 
@@ -108,13 +110,14 @@ canvas.addEventListener('mousemove', e => {
 
 // Restart button
 document.getElementById('restartBtn').addEventListener('click', () => {
+    cancelAnimationFrame(animationId); // Stop any existing loop
     score = 0;
     lives = 5;
     leaves = [];
     basket.x = canvas.width / 2 - 40;
     gameOver = false;
-    update();
+    animationId = requestAnimationFrame(update); // Start a fresh loop
 });
 
 // Start game
-update();
+animationId = requestAnimationFrame(update);


### PR DESCRIPTION
This pull request fixes the game restart issue where multiple requestAnimationFrame() loops could be triggered after repeatedly pressing the Restart button. It ensures the game loop is properly cancelled before restarting, preventing performance issues and gameplay glitches.

Changes Made
Added cancelAnimationFrame(animationId) before starting a new animation loop.
Introduced animationId tracking to safely stop and restart the main loop.
Updated the restart logic to fully reset game state (score, lives, leaves, basket position).
Switched leaf iteration to a reverse loop to avoid skipped elements when removing items.
Confirmed the restart button now resets gameplay smoothly and consistently.

How to Test
Run the game and play until Game Over appears.
Click the Restart button.

Observe that:
Leaves fall normally (only one loop active).
Score and lives reset to zero and five respectively.
The game speed remains consistent after multiple restarts.

Related Issue
Closes – Game not restarting properly

Impact
Prevents multiple overlapping animation loops.
Improves stability and performance after restarts.
Ensures consistent game behavior without manual page reloads.

Notes
No visual changes to the gameplay interface.
Future improvements could include adding pause functionality and smoother transition animations.